### PR TITLE
Reference 'currency' instead of 'value_currency'

### DIFF
--- a/lib/amountable/jsonb_methods.rb
+++ b/lib/amountable/jsonb_methods.rb
@@ -6,7 +6,7 @@ module Amountable
 
     def amounts
       @_amounts ||= attribute(amounts_column_name).to_h['amounts'].to_h.map do |name, amount|
-        Amount.new(name: name, value_cents: amount['cents'], value_currency: amount['value_currency'], persistable: false, amountable: self)
+        Amount.new(name: name, value_cents: amount['cents'], value_currency: amount['currency'], persistable: false, amountable: self)
       end.to_set
     end
 

--- a/lib/amountable/version.rb
+++ b/lib/amountable/version.rb
@@ -1,5 +1,5 @@
 # Copyright 2015-2017, Instacart
 
 module Amountable
-  VERSION = '0.2.6'
+  VERSION = '0.2.7'
 end


### PR DESCRIPTION
The currency value is stored in the `jsonb` column under the `'currency'` key, not `'value_currency'`.