### PR TITLE
Be less forward defensive

### DIFF
--- a/amountable.gemspec
+++ b/amountable.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.required_ruby_version     = '>= 2.1.1'
 
-  gem.add_dependency 'activerecord', '>= 4.1', '< 5.3'
-  gem.add_dependency 'activesupport', '>= 4.1', '< 5.3'
+  gem.add_dependency 'activerecord', '>= 4.1'
+  gem.add_dependency 'activesupport', '>= 4.1'
   gem.add_dependency 'activerecord-import', '~> 0.19.1'
   gem.add_dependency 'money-rails', '>=1.7.0'
   gem.add_dependency 'monetize'


### PR DESCRIPTION
ActiveRecord and ActiveSupport have a decent backward compatibility track record, with graceful deprecations between major version bumps. We should assume compatibility to unblock clients until proven otherwise.