### PR TITLE
bump version for rails 6

### DIFF
--- a/lib/amountable/version.rb
+++ b/lib/amountable/version.rb
@@ -1,5 +1,5 @@
 # Copyright 2015-2017, Instacart
 
 module Amountable
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
Bump version for amountable to make it rails 6 compliant on https://rubygems.org/gems/amountable