### PR TITLE
Set up automatic publishing to Github and Rubygems

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,0 +1,33 @@
+name: Ruby Gem
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build + Publish
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+    - name: Build
+      run: |
+        gem build *.gemspec
+    - name: Publish to Github
+      run: |
+        mkdir -p $HOME/.gem
+        touch $HOME/.gem/credentials
+        chmod 0600 $HOME/.gem/credentials
+        printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+        gem push --verbose --key github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+      env:
+        GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+        OWNER: ${{ github.repository_owner }}
+    - name: Publish to RubyGems
+      run: |
+        gem push --verbose *.gem
+      env:
+        GEM_HOST_API_KEY: ${{secrets.RUBYGEMS_TOKEN}}


### PR DESCRIPTION
This isn't 100% ready because we need to set a `RUBYGEMS_TOKEN` secret, but that can be done after this is merged.