### PR TITLE
Allow Github publish to fail

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -26,6 +26,7 @@ jobs:
       env:
         GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
         OWNER: ${{ github.repository_owner }}
+      continue-on-error: true
     - name: Publish to RubyGems
       run: |
         gem push --verbose *.gem


### PR DESCRIPTION
Public Github gems can't be yanked the way Rubygems ones can, so we need to make this step fault-tolerant