### PR TITLE
Adjust build settings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:

--- a/.github/workflows/gem-publish-public.yml
+++ b/.github/workflows/gem-publish-public.yml
@@ -1,4 +1,4 @@
-name: Ruby Gem
+name: Publish Public Gem
 
 on:
   release:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: ruby
-rvm:
- - 2.2.2
-addons:
-  postgresql: "9.4"


### PR DESCRIPTION
* Remove Travis. No longer needed
* Limit when CI builds get triggered
* Clarify publish action is meant for public gems