### PR TITLE
Support Ruby 3.0 and 3.1, drop Ruby 2.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,12 +12,18 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.6'
+          - '3.1'
+          - '3.0'
           - '2.7'
         activerecord:
           - '6.1'
           - '6.0'
           - '5.2'
+        exclude:
+          - activerecord: '5.2'
+            ruby: '3.0'
+          - activerecord: '5.2'
+            ruby: '3.1'
     services:
       postgres:
         image: postgres:12

--- a/amountable.gemspec
+++ b/amountable.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.test_files    = gem.files.grep(%r{^spec/})
   gem.require_paths = ['lib']
-  gem.required_ruby_version     = '>= 2.6'
+  gem.required_ruby_version     = '>= 2.7'
 
   gem.add_dependency 'activerecord', '>= 5.2', '< 7'
   gem.add_dependency 'activerecord-import', '>= 0.19.1'

--- a/lib/amountable.rb
+++ b/lib/amountable.rb
@@ -119,6 +119,7 @@ module Amountable
         super
       end
     end
+    ruby2_keywords :where if Module.private_method_defined?(:ruby2_keywords)
 
     def where_json(opts, *rest)
       values = []
@@ -136,6 +137,7 @@ module Amountable
       query = [query.join(' AND ')] + values
       where(query, *rest).where(opts, *rest)
     end
+    ruby2_keywords :where_json if Module.private_method_defined?(:ruby2_keywords)
 
     def pg_json_field_access(name, field = :cents)
       name = name.to_sym

--- a/lib/amountable/table_methods.rb
+++ b/lib/amountable/table_methods.rb
@@ -19,15 +19,15 @@ module Amountable
       amount.value
     end
 
-    def save(args = {})
+    def save(**args)
       ActiveRecord::Base.transaction do
-        save_amounts if super(args)
+        save_amounts if super
       end
     end
 
-    def save!(args = {})
+    def save!(**args)
       ActiveRecord::Base.transaction do
-        save_amounts! if super(args)
+        save_amounts! if super
       end
     end
 

--- a/spec/support/database.rb
+++ b/spec/support/database.rb
@@ -1,10 +1,16 @@
 # Copyright 2015-2021, Instacart
 
+require "activerecord-import/base"
+
 db_name = ENV['DB'] || 'postgresql'
 spec_dir = Pathname.new(File.dirname(__FILE__)) / '..'
 database_yml = spec_dir.join('internal/config/database.yml')
 
 fail "Please create #{database_yml} first to configure your database. Take a look at: #{database_yml}.sample" unless File.exist?(database_yml)
+
+module ActiveRecord::Import::Connection
+  ruby2_keywords :establish_connection if Module.private_method_defined?(:ruby2_keywords)
+end
 
 ActiveRecord::Migration.verbose = false
 ActiveRecord::Base.default_timezone = :utc


### PR DESCRIPTION
* Ruby 2.6 is EOL
* Ruby 3.0 and 3.1 are out
* Rails 5.2 doesn't support Ruby > 2.7